### PR TITLE
Add free format attribute to urlset and extend items freely.

### DIFF
--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -193,9 +193,10 @@ class Sitemap {
 	 * @param string|null $priority The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0.
 	 * @param string|null $changefreq How frequently the page is likely to change. Valid values are always, hourly, daily, weekly, monthly, yearly and never.
 	 * @param string|int|null $lastmod The date of last modification of url. Unix timestamp or any English textual datetime description.
+	 * @param callable|null $ext Use if you want to add other attribute or child element. callable's 1st argument MUST BE XMLWriter ( * $this->getWriter() ).
 	 * @return Sitemap
 	 */
-	public function addItem($loc, $priority = self::DEFAULT_PRIORITY, $changefreq = NULL, $lastmod = NULL) {
+	public function addItem($loc, $priority = self::DEFAULT_PRIORITY, $changefreq = NULL, $lastmod = NULL, $ext = NULL) {
 		if (($this->getCurrentItem() % self::ITEM_PER_SITEMAP) == 0) {
 			if ($this->getWriter() instanceof \XMLWriter) {
 				$this->endSitemap();
@@ -212,6 +213,8 @@ class Sitemap {
 			$this->getWriter()->writeElement('changefreq', $changefreq);
 		if ($lastmod)
 			$this->getWriter()->writeElement('lastmod', $this->getLastModifiedDate($lastmod));
+		if ($ext && is_callable($ext))
+			$ext($this->getWriter());
 		$this->getWriter()->endElement();
 		return $this;
 	}

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -121,7 +121,7 @@ class Sitemap {
 	}
 
 	/**
-	 * Add sitemap attribute
+	 * Add sitemap urlset attribute
 	 *
 	 * @param string $name
 	 * @param string $value

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -73,7 +73,7 @@ class Sitemap {
 	/**
 	 * Assigns XMLWriter object instance
 	 *
-	 * @param \XMLWriter $writer 
+	 * @param \XMLWriter $writer
 	 */
 	private function setWriter(\XMLWriter $writer) {
 		$this->writer = $writer;
@@ -81,7 +81,7 @@ class Sitemap {
 
 	/**
 	 * Returns path of sitemaps
-	 * 
+	 *
 	 * @return string
 	 */
 	private function getPath() {
@@ -90,7 +90,7 @@ class Sitemap {
 
 	/**
 	 * Sets paths of sitemaps
-	 * 
+	 *
 	 * @param string $path
 	 * @return Sitemap
 	 */
@@ -101,7 +101,7 @@ class Sitemap {
 
 	/**
 	 * Returns filename of sitemap file
-	 * 
+	 *
 	 * @return string
 	 */
 	private function getFilename() {
@@ -110,7 +110,7 @@ class Sitemap {
 
 	/**
 	 * Sets filename of sitemap file
-	 * 
+	 *
 	 * @param string $filename
 	 * @return Sitemap
 	 */
@@ -130,7 +130,7 @@ class Sitemap {
 
 	/**
 	 * Increases item counter
-	 * 
+	 *
 	 */
 	private function incCurrentItem() {
 		$this->current_item = $this->current_item + 1;
@@ -147,7 +147,7 @@ class Sitemap {
 
 	/**
 	 * Increases sitemap file count
-	 * 
+	 *
 	 */
 	private function incCurrentSitemap() {
 		$this->current_sitemap = $this->current_sitemap + 1;
@@ -155,7 +155,7 @@ class Sitemap {
 
 	/**
 	 * Prepares sitemap XML document
-	 * 
+	 *
 	 */
 	private function startSitemap() {
 		$this->setWriter(new \XMLWriter());
@@ -173,7 +173,7 @@ class Sitemap {
 	/**
 	 * Adds an item to sitemap
 	 *
-	 * @param string $loc URL of the page. This value must be less than 2,048 characters. 
+	 * @param string $loc URL of the page. This value must be less than 2,048 characters.
 	 * @param string|null $priority The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0.
 	 * @param string|null $changefreq How frequently the page is likely to change. Valid values are always, hourly, daily, weekly, monthly, yearly and never.
 	 * @param string|int|null $lastmod The date of last modification of url. Unix timestamp or any English textual datetime description.

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -26,6 +26,7 @@ class Sitemap {
 	private $filename = 'sitemap';
 	private $current_item = 0;
 	private $current_sitemap = 0;
+	private $urlset_attributes = array();
 
 	const EXT = '.xml';
 	const SCHEMA = 'http://www.sitemaps.org/schemas/sitemap/0.9';
@@ -120,6 +121,18 @@ class Sitemap {
 	}
 
 	/**
+	 * Add sitemap attribute
+	 *
+	 * @param string $name
+	 * @param string $value
+	 * @return Sitemap
+	 */
+	public function addUrlsetAttribute($name, $value) {
+		$this->urlset_attributes[] = compact('name', 'value');
+		return $this;
+	}
+
+	/**
 	 * Returns current item count
 	 *
 	 * @return int
@@ -168,6 +181,9 @@ class Sitemap {
 		$this->getWriter()->setIndent(true);
 		$this->getWriter()->startElement('urlset');
 		$this->getWriter()->writeAttribute('xmlns', self::SCHEMA);
+		foreach($this->urlset_attributes as $attr) {
+			$this->getWriter()->writeAttribute($attr['name'], $attr['value']);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Some people need extension, like #6 , or many media type format.
e.g.
* https://support.google.com/news/publisher/answer/74288
* https://developers.google.com/webmasters/mobile-sites/mobile-seo/configurations/separate-urls#annotation-in-sitemaps
* https://support.google.com/webmasters/answer/2620865

this pull request extend urlset attribute (we can add some attribute, ex. `xmlsn:xhtml` ) and add new elements to `url` items using `callable`.

sample code:
```php
$sitemap = new Sitemap("http://hogehoge.com");
$sitemap->addUrlsetAttribute("xmlns:mobile", "http://www.google.com/schemas/sitemap-mobile/1.0");
$sitemap->addItem("/", 1.0, "hourly", date("Y-m-d H:i:s"), function(\XMLWriter $writer){
  $writer->writeElement("mobile:mobile");
});
```