### PR TITLE
Writing to output stream rather than file. 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+1.3.0-stable (2018-08-27)
+	* Write xml to stream and return instead of handling right to file
+
 1.2.0-stable (2015-04-17)
 	* Now licensed as MIT.
 	* Fixed: Fix fatal error on empty sitemap. Patch my @mkly.

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2009-2015 Osman Üngür
 Copyright (c) 2012-2015 Evert Pot (http://evertpot.com/)
+Copyright (c) 2018 Sofiac 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "evert/sitemap-php",
+    "name": "sofiac/sitemap-php",
     "type": "library",
     "description": "Lightweight library for generating Google sitemap XML files",
     "keywords": ["Sitemap"],
-    "homepage": "https://github.com/evert/sitemap-php/",
+    "homepage": "https://github.com/SofiacImmersionWorkingGroup/sitemap-php",
     "license": "MIT",
     "authors": [
         {
@@ -13,6 +13,9 @@
         {
             "name": "Evert Pot",
             "email": "evert@rooftopsolutions.nl"
+        },
+        {
+          "name": "Sofiac"
         }
     ],
     "require": {

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -155,15 +155,20 @@ class Sitemap {
 
 	/**
 	 * Prepares sitemap XML document
+   * @param bool $outputStream Ignore the default path for writing to a file and echo out the file.
 	 * 
 	 */
-	private function startSitemap() {
+	private function startSitemap($outputStream) {
 		$this->setWriter(new \XMLWriter());
-		if ($this->getCurrentSitemap()) {
-			$this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . $this->getCurrentSitemap() . self::EXT);
-		} else {
-			$this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::EXT);
-		}
+    if($outputStream) {
+      $this->getWriter()->openURI("php://output");
+    } else {
+      if ($this->getCurrentSitemap()) {
+        $this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . $this->getCurrentSitemap() . self::EXT);
+      } else {
+        $this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::EXT);
+      }
+    }
 		$this->getWriter()->startDocument('1.0', 'UTF-8');
 		$this->getWriter()->setIndent(true);
 		$this->getWriter()->startElement('urlset');
@@ -177,14 +182,15 @@ class Sitemap {
 	 * @param string|null $priority The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0.
 	 * @param string|null $changefreq How frequently the page is likely to change. Valid values are always, hourly, daily, weekly, monthly, yearly and never.
 	 * @param string|int|null $lastmod The date of last modification of url. Unix timestamp or any English textual datetime description.
+   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 * @return Sitemap
 	 */
-	public function addItem($loc, $priority = self::DEFAULT_PRIORITY, $changefreq = NULL, $lastmod = NULL) {
+	public function addItem($loc, $priority = self::DEFAULT_PRIORITY, $changefreq = NULL, $lastmod = NULL, $outputStream = false) {
 		if (($this->getCurrentItem() % self::ITEM_PER_SITEMAP) == 0) {
 			if ($this->getWriter() instanceof \XMLWriter) {
-				$this->endSitemap();
+				$this->endSitemap($outputStream);
 			}
-			$this->startSitemap();
+			$this->startSitemap($outputStream);
 			$this->incCurrentSitemap();
 		}
 		$this->incCurrentItem();
@@ -217,11 +223,12 @@ class Sitemap {
 
 	/**
 	 * Finalizes tags of sitemap XML document.
-	 *
+   * 
+   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
-	private function endSitemap() {
+	private function endSitemap($outputStream) {
 		if (!$this->getWriter()) {
-			$this->startSitemap();
+			$this->startSitemap($outputStream);
 		}
 		$this->getWriter()->endElement();
 		$this->getWriter()->endDocument();
@@ -232,11 +239,16 @@ class Sitemap {
 	 *
 	 * @param string $loc Accessible URL path of sitemaps
 	 * @param string|int $lastmod The date of last modification of sitemap. Unix timestamp or any English textual datetime description.
+   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
-	public function createSitemapIndex($loc, $lastmod = 'Today') {
-		$this->endSitemap();
+	public function createSitemapIndex($loc, $lastmod = 'Today', $outputStream = false) {
+		$this->endSitemap($outputStream);
 		$indexwriter = new \XMLWriter();
-		$indexwriter->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . self::INDEX_SUFFIX . self::EXT);
+    if($outputStream) {
+      $indexwriter->openURI("php://output");
+    } else {
+		  $indexwriter->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . self::INDEX_SUFFIX . self::EXT);
+    }
 		$indexwriter->startDocument('1.0', 'UTF-8');
 		$indexwriter->setIndent(true);
 		$indexwriter->startElement('sitemapindex');

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -11,8 +11,9 @@ namespace SitemapPHP;
  * @author     Osman Üngür <osmanungur@gmail.com>
  * @copyright  2009-2015 Osman Üngür
  * @copyright  2012-2015 Evert Pot (http://evertpot.com/)
+ * @copyright  2018 Sofiac
  * @license    http://opensource.org/licenses/MIT MIT License
- * @link       http://github.com/evert/sitemap-php
+ * @link       https://github.com/SofiacImmersionWorkingGroup/sitemap-php
  */
 class Sitemap {
 

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -226,7 +226,7 @@ class Sitemap {
    * 
    * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
-	private function endSitemap($outputStream) {
+	public function endSitemap($outputStream) {
 		if (!$this->getWriter()) {
 			$this->startSitemap($outputStream);
 		}

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -155,20 +155,20 @@ class Sitemap {
 
 	/**
 	 * Prepares sitemap XML document
-   * @param bool $outputStream Ignore the default path for writing to a file and echo out the file.
+	 * @param bool $outputStream Ignore the default path for writing to a file and echo out the file.
 	 * 
 	 */
 	private function startSitemap($outputStream) {
 		$this->setWriter(new \XMLWriter());
-    if($outputStream) {
-      $this->getWriter()->openURI("php://output");
-    } else {
-      if ($this->getCurrentSitemap()) {
-        $this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . $this->getCurrentSitemap() . self::EXT);
-      } else {
-        $this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::EXT);
-      }
-    }
+		if($outputStream) {
+			$this->getWriter()->openURI("php://output");
+		} else {
+			if ($this->getCurrentSitemap()) {
+				$this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . $this->getCurrentSitemap() . self::EXT);
+			} else {
+				$this->getWriter()->openURI($this->getPath() . $this->getFilename() . self::EXT);
+			}
+		}
 		$this->getWriter()->startDocument('1.0', 'UTF-8');
 		$this->getWriter()->setIndent(true);
 		$this->getWriter()->startElement('urlset');
@@ -182,7 +182,7 @@ class Sitemap {
 	 * @param string|null $priority The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0.
 	 * @param string|null $changefreq How frequently the page is likely to change. Valid values are always, hourly, daily, weekly, monthly, yearly and never.
 	 * @param string|int|null $lastmod The date of last modification of url. Unix timestamp or any English textual datetime description.
-   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
+	 * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 * @return Sitemap
 	 */
 	public function addItem($loc, $priority = self::DEFAULT_PRIORITY, $changefreq = NULL, $lastmod = NULL, $outputStream = false) {
@@ -223,8 +223,8 @@ class Sitemap {
 
 	/**
 	 * Finalizes tags of sitemap XML document.
-   * 
-   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
+	 * 
+	 * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
 	public function endSitemap($outputStream) {
 		if (!$this->getWriter()) {
@@ -239,16 +239,16 @@ class Sitemap {
 	 *
 	 * @param string $loc Accessible URL path of sitemaps
 	 * @param string|int $lastmod The date of last modification of sitemap. Unix timestamp or any English textual datetime description.
-   * @param bool $outputStream Ignore the default path to write a file and echo out the file.
+	 * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
 	public function createSitemapIndex($loc, $lastmod = 'Today', $outputStream = false) {
 		$this->endSitemap($outputStream);
 		$indexwriter = new \XMLWriter();
-    if($outputStream) {
-      $indexwriter->openURI("php://output");
-    } else {
-		  $indexwriter->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . self::INDEX_SUFFIX . self::EXT);
-    }
+		if($outputStream) {
+			$indexwriter->openURI("php://output");
+		} else {
+			$indexwriter->openURI($this->getPath() . $this->getFilename() . self::SEPERATOR . self::INDEX_SUFFIX . self::EXT);
+		}
 		$indexwriter->startDocument('1.0', 'UTF-8');
 		$indexwriter->setIndent(true);
 		$indexwriter->startElement('sitemapindex');

--- a/src/SitemapPHP/Sitemap.php
+++ b/src/SitemapPHP/Sitemap.php
@@ -158,7 +158,7 @@ class Sitemap {
 	 * @param bool $outputStream Ignore the default path for writing to a file and echo out the file.
 	 * 
 	 */
-	private function startSitemap($outputStream) {
+	private function startSitemap($outputStream = false) {
 		$this->setWriter(new \XMLWriter());
 		if($outputStream) {
 			$this->getWriter()->openURI("php://output");
@@ -226,7 +226,7 @@ class Sitemap {
 	 * 
 	 * @param bool $outputStream Ignore the default path to write a file and echo out the file.
 	 */
-	public function endSitemap($outputStream) {
+	public function endSitemap($outputStream = false) {
 		if (!$this->getWriter()) {
 			$this->startSitemap($outputStream);
 		}


### PR DESCRIPTION
Update sitemap.php to allow the xml to be passed to php's write-only stream, similar to an echo call. 

Also updated to allow a user to handle when a sitemap ends rather than calling the createSitemapIndex function. 
